### PR TITLE
Strip channel Guild/Channel ID from minId/maxId input

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -64,8 +64,8 @@
         const authorId = $('input#authorId').value.trim();
         const guildId = $('input#guildId').value.trim();
         const channelIds = $('input#channelId').value.trim().split(/\s*,\s*/);
-        const minId = $('input#minId').value.trim();
-        const maxId = $('input#maxId').value.trim();
+        const minId = $('input#minId').value.split("-").pop().trim();
+        const maxId = $('input#maxId').value.split("-").pop().trim();
         const minDate = $('input#minDate').value.trim();
         const maxDate = $('input#maxDate').value.trim();
         const content = $('input#content').value.trim();

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -376,8 +376,8 @@ function initUI() {
         const authorId = $('input#authorId').value.trim();
         const guildId = $('input#guildId').value.trim();
         const channelIds = $('input#channelId').value.trim().split(/\s*,\s*/);
-        const minId = $('input#minId').value.trim();
-        const maxId = $('input#maxId').value.trim();
+        const minId = $('input#minId').value.split("-").pop().trim();
+        const maxId = $('input#maxId').value.split("-").pop().trim();
         const minDate = $('input#minDate').value.trim();
         const maxDate = $('input#maxDate').value.trim();
         const content = $('input#content').value.trim();

--- a/help/messageId.md
+++ b/help/messageId.md
@@ -1,6 +1,6 @@
 # messageId
 You can delete all messages after a specific message, before a specific message, or everything between two points. For that you need to provide a messageID:
-- Right click a message, and click [Copy ID](./developerMode.md)
+- Hover the mouse over a message with your mouse while holding the shift key pressed, and click [Copy ID](./developerMode.md)
 > If the `Copy ID` doesn't show up, you need to enable [Developer mode](./developerMode.md) first.
 
 ----


### PR DESCRIPTION
Hi,

Copying the message ID from a message (while hovering a message with shift key pressed) copy both the channel ID and the message ID (separated with a '-' character) but the input boxes "After message with ID" and "Before message with ID" take only the user ID.
My little changes allow the user to past directly the input as directly copied to the input boxes without needing to manually strip the channel ID.
I also updated the documentation which was outdated.

Thanks for this useful tool!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/156)
<!-- Reviewable:end -->
