### PR TITLE
Fix Grammar/Typos in Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -16,7 +16,7 @@ body:
 - type: input
   attributes:
     label: Undiscord Version
-    description: You can see the version in the bottom right corner or in the ViolentMonkey or TamperMonkey settings.
+    description: You can see the version in the bottom right corner or in the Violentmonkey or TamperMonkey settings.
     placeholder: v0.0.0
   validations:
     required: true
@@ -31,7 +31,7 @@ body:
   attributes:
     label: Extension
     description: Which extension are you using
-    placeholder: ViolentMonkey / TamperMonkey / Other method
+    placeholder: Violentmonkey / TamperMonkey / Other method
   validations:
     required: true
 - type: textarea
@@ -65,10 +65,10 @@ body:
       - label: Channel (NSFW)
 - type: textarea
   attributes:
-    label: Additional information & file uploads  
+    label: Additional information & file uploads
     description: |
       You can add screenshots and additional information that is relevant to the issue in the comments below.
       IMPORTANT: Make sure to verify you're not sharing any personal information. Redact any ID's or Names that might appear.
-      Github Issues are publicly visible, do not post sensitive information here!
+      GitHub Issues are publicly visible, do not post sensitive information here!
   validations:
     required: true

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@
     
 1. Install Undiscord:  
   [![][greasyfork_icon]][greasyfork_url] or [![][openuserjs_icon]][openuserjs_url]  
-  (NOTE: GreasyFork is recommended for now, OpenUserJS is not receiving updates)
+  (NOTE: Greasy Fork is recommended for now, OpenUserJS is not receiving updates)
 
 1. Open <a href="https://discord.com/channels/@me" target="_blank">Discord</a> in your __browser__ (Not the App) and go to the channel or direct message you would like to be wiped.
 
-1. Click the <kbd>🗑️</kbd> button that was added in the top right corner.
+1. Click the <kbd>🗑️</kbd> button that was added in the top-right corner.
 
 1. Click on the buttons near **Author ID** and **Server ID** and **Channel ID**.  
 
@@ -68,10 +68,10 @@ Originally from https://gist.github.com/victornpb/135f5b346dea4decfc8f63ad7d9cc1
 ## ⛔️ DO NOT SHARE YOUR AUTH TOKEN! ⛔️ ##
 
 Sharing your authToken on the internet will give full access to your account! [There are bots gathering credentials all over the internet](https://github.com/rndinfosecguy/Scavenger).
-If you post your token by accident, LOGOUT from discord on that **same browser** you got that token imediately.
-Changing your password will make sure that you get logged out of every device. I advice that you turn on [2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) afterwards.
+If you post your token accidentally, LOGOUT from Discord on that **same browser** you got that token immediately.
+Changing your password will make sure that you get logged out of every device. I advise that you turn on [2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) afterwards.
 
-If you are unsure do not post screenshots, or logs on the internet.
+If you are unsure, do not post screenshots or logs on the internet.
 
 ----
 ## Security Concerns
@@ -121,5 +121,5 @@ Please read: [what I'm doing to ensure this is safe for users][security_policy].
   [opera_violentmonkey]: https://addons.opera.com/extensions/details/violent-monkey/
 
 <!-- Download links -->
-  [greasyfork_url]: <https://greasyfork.org/en/scripts/406540-undiscord-delete-all-messages-in-a-discord-channel-or-dm-bulk-deletion> "Get Undiscord from GreasyFork"
+  [greasyfork_url]: <https://greasyfork.org/en/scripts/406540-undiscord-delete-all-messages-in-a-discord-channel-or-dm-bulk-deletion> "Get Undiscord from Greasy Fork"
   [openuserjs_url]: <https://openuserjs.org/scripts/victornpb/Undiscord_-_Delete_all_messages_in_a_Discord_channel_or_DM_(Bulk_deletion)> "Get Undiscord from OpenUserJS"

--- a/help/authToken.md
+++ b/help/authToken.md
@@ -14,9 +14,9 @@
 # DO NOT SHARE YOUR `authToken`!
 
 > Sharing your authToken on the internet will give full access to your account! [There are bots gathering credentials all over the internet](https://github.com/rndinfosecguy/Scavenger).
-If you post your token by accident, LOGOUT from discord on that **same browser** you got that token imediately.
-Changing your password will make sure that you get logged out of every device. I advice that you turn on [2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) afterwards.
+If you post your token accidentally, LOGOUT from Discord on that **same browser** you got that token immediately.
+Changing your password will make sure that you get logged out of every device. I advise that you turn on [2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) afterwards.
 
-If you are unsure do not share screenshots, or copy paste logs on the internet.
+If you are unsure do not share screenshots, or copy and paste logs on the internet.
 
 ----

--- a/help/authorId.md
+++ b/help/authorId.md
@@ -2,15 +2,15 @@
 
 ## The easy way
 
- - Just click **Me** button next to "Author" in the popup window, 
-   it should auto detect your ID.
+ - Just click **Me** button next to "Author" in the popup window,
+   it should auto-detect your ID.
 
 
 ## The manual way
-- Right click your **avatar** in a message you sent in the chat, [Copy ID](./developerMode.md)  
+- Right-click your **avatar** in a message you sent in the chat, [Copy ID](./developerMode.md)  
   <img src="https://media.giphy.com/media/YnNTRqKRxVcjOuyFps/giphy.gif">  
   NOT THE MESSAGE THE AVATAR.  
-  (You cannot delete the other's person messages a in DM channel, you will get Error 403)
+  (You can't delete messages from another person in a DM channel; you will get an Error 403.)
 
 
 -----

--- a/help/channelId.md
+++ b/help/channelId.md
@@ -17,13 +17,13 @@
 ## The manual way
 
 ### For public channels:
-- Right click a channel, [Copy ID](./developerMode.md)
+- Right-click a channel, [Copy ID](./developerMode.md)
 <img src=https://media.giphy.com/media/UqBPG05BIP3Vkj7Pby/giphy.gif>
 
 
 ### For a DM/Direct messages:
 
-- copy the number after /@me/ in the URL)
+- Copy the number after /@me/ in the URL)
 <img src="https://user-images.githubusercontent.com/3372598/58374439-d9739f80-7f2d-11e9-85f4-3c241a85a8bb.png" height="200">
 
 ---
@@ -34,7 +34,7 @@ You can target multiple channels in sequence by separating them with a comma.
 
 ## Deleting all messages by using the "Request a Copy of your Data" option
 
-To delete all message from every (user) channel do following:
+To delete all message from every (user) channel, do the following:
 1. Go to "User Settings -> Privacy and Safety" and click on "Request all my Data."
 2. You should receive an email within the next 30 days
 3. Click on the "Import JSON" button the right JSON file is called "index.json" and is located in the messages folder (messages/index.json).

--- a/help/delay.md
+++ b/help/delay.md
@@ -1,3 +1,3 @@
 # Search and Delete Delay
 
-This setting controls the initial delay for for searching messages. Sometimes the Discord API will quickly rate limit you, in this case setting the delays to something higher might help. This is especially true for the **Delete Delay**.
+This setting controls the initial delay for searching messages. Sometimes the Discord API will quickly rate limit you, in this case setting the delays to something higher might help. This is especially true for the **Delete Delay**.

--- a/help/developerMode.md
+++ b/help/developerMode.md
@@ -1,6 +1,6 @@
 # Developer Mode
 
-If the `Copy ID` menu doesn't show up when right clicking:  
+If the `Copy ID` menu doesn't show up when right-clicking:  
  - Enable developer mode in discord
    Go to user **Settings** > **Appearance** in discord and enable **Developer mode**. 
 

--- a/help/messageId.md
+++ b/help/messageId.md
@@ -1,6 +1,6 @@
 # messageId
-You can delete all messages after a specific message, before a specific message, or everything between two points. For that you need to provide a messageID:
-- Right click a message, and click [Copy ID](./developerMode.md)
+You can delete all messages after a specific message, before a specific message, or everything between two points. For that, you need to provide a messageID:
+- Right-click a message, and click [Copy ID](./developerMode.md)
 > If the `Copy ID` doesn't show up, you need to enable [Developer mode](./developerMode.md) first.
 
 ----


### PR DESCRIPTION
When reading the README/docs for this project, I just saw some typos and improper English and wanted to address them.

I only skimmed over it while I was reading the docs, so I might not have fixed everything, but it should be a bit more comfortable to read to native English speakers now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/164)
<!-- Reviewable:end -->
