### PR TITLE
Added MIT License to Repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-2021 victornpb and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Fixes #159 

> ```js
> // @license       MIT
> ```
> \- https://github.com/victornpb/deleteDiscordMessages/blob/master/deleteDiscordMessages.user.js#L12

I noticed that there is a license specified in `deleteDiscordMessages.user.js`, but the license or license terms aren't made explicit anywhere in the repository.

I think it'd be nice to have a license in the root of the repository like any other open-source project.  

This way it'll be:
* More consistent with other projects.
* GitHub can display the license on the project details.
* You could remove the **DISCLAIMER** of warranty clause from the README as that's covered by the license anyway.

(Regardless, since this is MIT licensed, I'd recommend swapping the wording out for the MIT warranty clause, or removing it from the README entirely, but that's up to you.)

More information with the issues that can come from accepting contributions without a license.

https://choosealicense.com/no-permission/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/166)
<!-- Reviewable:end -->
