### PR TITLE
Treat retry_after on API response as seconds rather than milliseconds.

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -772,7 +772,7 @@
 
       // not indexed yet
       if (resp.status === 202) {
-        const w = (await resp.json()).retry_after;
+        const w = (await resp.json()).retry_after * 1000;
         throttledCount++;
         throttledTotalTime += w;
         log.warn(`This channel wasn't indexed, waiting ${w}ms for discord to index it...`);
@@ -783,7 +783,7 @@
       if (!resp.ok) {
         // searching messages too fast
         if (resp.status === 429) {
-          const w = (await resp.json()).retry_after;
+          const w = (await resp.json()).retry_after * 1000;
           throttledCount++;
           throttledTotalTime += w;
           searchDelay += w; // increase delay
@@ -867,7 +867,7 @@
           if (!resp.ok) {
             // deleting messages too fast
             if (resp.status === 429) {
-              const w = (await resp.json()).retry_after;
+              const w = (await resp.json()).retry_after  *  1000;
               throttledCount++;
               throttledTotalTime += w;
               deleteDelay = w; // increase delay

--- a/src/deleteMessages.js
+++ b/src/deleteMessages.js
@@ -84,7 +84,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
     // not indexed yet
     if (resp.status === 202) {
-      const w = (await resp.json()).retry_after;
+      const w = (await resp.json()).retry_after * 1000;
       throttledCount++;
       throttledTotalTime += w;
       log.warn(`This channel wasn't indexed, waiting ${w}ms for discord to index it...`);
@@ -95,7 +95,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     if (!resp.ok) {
       // searching messages too fast
       if (resp.status === 429) {
-        const w = (await resp.json()).retry_after;
+        const w = (await resp.json()).retry_after * 1000;
         throttledCount++;
         throttledTotalTime += w;
         searchDelay += w; // increase delay
@@ -179,7 +179,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         if (!resp.ok) {
           // deleting messages too fast
           if (resp.status === 429) {
-            const w = (await resp.json()).retry_after;
+            const w = (await resp.json()).retry_after * 1000;
             throttledCount++;
             throttledTotalTime += w;
             deleteDelay = w; // increase delay


### PR DESCRIPTION
This should fix #348 - looking at the [Discord API rate limits docs](https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit), we can see:

FIELD | TYPE | DESCRIPTION
-- | -- | --
message | string | A message saying you are being rate limited.
retry_after | float | The number of seconds to wait before submitting another request.
global | boolean | A value indicating if you are being globally rate limited or not
