### PR TITLE
Grammar correction: throwed -> threw

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -859,7 +859,7 @@
             avgPing = (avgPing * 0.9) + (lastPing * 0.1);
             delCount++;
           } catch (err) {
-            log.error('Delete request throwed an error:', err);
+            log.error('Delete request threw an error:', err);
             log.verb('Related object:', redact(JSON.stringify(message)));
             failCount++;
           }

--- a/src/deleteMessages.js
+++ b/src/deleteMessages.js
@@ -171,7 +171,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
           avgPing = (avgPing * 0.9) + (lastPing * 0.1);
           delCount++;
         } catch (err) {
-          log.error('Delete request throwed an error:', err);
+          log.error('Delete request threw an error:', err);
           log.verb('Related object:', redact(JSON.stringify(message)));
           failCount++;
         }


### PR DESCRIPTION
"Throwed" is English, specific to some dialects, "threw" is dialect-agnostic.