### PR TITLE
Update default delete delay

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -646,7 +646,7 @@
                         <a href="{{WIKI}}/delay" title="Help" target="_blank">help</a>
                     </legend>
                     <div class="input-wrapper">
-                        <input id="deleteDelay" type="number" value="1000" step="100">
+                        <input id="deleteDelay" type="number" value="2500" step="100">
                     </div>
                     <br>
                     <div class="sectionDescription">

--- a/help/delay.md
+++ b/help/delay.md
@@ -1,3 +1,5 @@
 # Search and Delete Delay
 
-This setting controls the initial delay for for searching messages. Sometimes the Discord API will quickly rate limit you, in this case setting the delays to something higher might help. This is especially true for the **Delete Delay**.
+This setting controls the initial delay for searching messages. Sometimes the Discord API will quickly rate limit you, in this case setting the delays to something higher might help. This is especially true for the **Delete Delay**.
+
+From testing a delete delay of 2000 ms is sometimes possible without being rate limited. By default it is set to 2500 ms as this will almost never result in rate limiting.


### PR DESCRIPTION
The default delay of 1000 ms was outdated and being rate limited with the old default delay has been inevitable for a while.

This PR updates the default delay to 2500 ms to prevent getting rate limited.