### PR TITLE
Fix README path for build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -95,7 +95,7 @@ function updateReadmeOutputTable() {
     return (startIndex !== -1 && endIndex !== -1) ? str.slice(0, startIndex + startString.length) + substitute + str.slice(endIndex) : str;
   }
   const fs = require('fs');
-  const readme = fs.readFileSync('README.md', 'utf8');
+  const readme = fs.readFileSync('readme.md', 'utf8');
   const outputDescription = generateOutputDescription(config);
   const newReadme = replaceBetween(readme, '<!-- Output table (auto generated do not modify) -->', '<!-- END -->', `\n\n${outputDescription}\n\n`);
   fs.writeFileSync('README.md', newReadme);


### PR DESCRIPTION
Without this, I get the following error:
```
❯ npm start  
                                                                                                                                                                                               
> undiscord@5.0.3 start
> npm run watch
                                                                                               

> undiscord@5.0.3 watch
> rollup -c -w

[!] Error: ENOENT: no such file or directory, open 'README.md'
Error: ENOENT: no such file or directory, open 'README.md'
    at Object.openSync (node:fs:599:3)
    at Object.readFileSync (node:fs:467:35)
    at updateReadmeOutputTable (/home/nyuszika7h/code/undiscord/rollup.config.js:179:21)
    at Object.<anonymous> (/home/nyuszika7h/code/undiscord/rollup.config.js:185:1)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Object.require.extensions.<computed> [as .js] (/home/nyuszika7h/code/undiscord/node_modules/rollup/dist/shared/loadConfigFile.js:614:20)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Function.Module._load (node:internal/modules/cjs/loader:838:12)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
```