### PR TITLE
Hack fix to skip messages that have been locked/archived

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -373,7 +373,6 @@
         </div>
     </div>
 </div>
-
 `);
 
 	const log = {
@@ -762,7 +761,7 @@
 	    }
 
 	    if (!resp.ok) {
-	      if (resp.status === 429) {
+          if (resp.status === 429) {
 	        // deleting messages too fast
 	        const w = (await resp.json()).retry_after * 1000;
 	        this.stats.throttledCount++;
@@ -773,7 +772,11 @@
 	        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 	        await wait(w * 2);
 	        return 'RETRY';
-	      } else {
+	      } else
+          if (resp.status === 400) {
+            // trying to delete a message that is in a locked or archived channel
+            log.warn('Message cannot be deleted as it is locked/archived!')
+          } else {
 	        // other error
 	        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
 	        log.verb('Related object:', redact(JSON.stringify(message)));
@@ -1025,7 +1028,6 @@ body.undiscord-pick-message [data-list-id="chat-messages"] {
   background-color: var(--background-secondary-alt);
   box-shadow: inset 0 0 0px 2px var(--button-outline-brand-border);
 }
-
 body.undiscord-pick-message [id^="message-content-"]:hover {
   cursor: pointer;
   cursor: cell;


### PR DESCRIPTION
This is a simple and temporary fix to skip the messages that are in a locked/archived channel or thread as currently the version on the main branch just gets stuck. I saw a PR with a fix but I decided to slap my own together quickly to get the benefits of 5.1.1 as the PR was on an outdated 5.0.3 build.