### PR TITLE
patch: skip archived messages after one attempt

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -830,7 +830,7 @@
 	            return 'FAIL_SKIP'; // Failed but we will skip it next time
 	          }
 
-	          log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+	          log.error(`Error deleting message, API responded with status ${resp.status}!`, r);
 	          log.verb('Related object:', redact(JSON.stringify(message)));
 	          this.state.failCount++;
 	          return 'FAILED';

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -814,6 +814,21 @@
 	        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 	        await wait(w * 2);
 	        return 'RETRY';
+	      } else if (resp.status === 400){
+	        // 400 can happen if the thread is archived (code=50083)
+	        // in this case we need to "skip" this message from the next search
+	        // otherwise it will come up again in the next page (and fail to delete again)
+	        (await resp.json()).code;
+	        if (code === 50083){
+	          log.warn(`Error deleting message (Thread is archived). Will increment offset so we don't search this in the next page...`);
+	          this.state.offset +=1 ;
+	          return 'FAIL_SKIP' ; // Failed but we will skip it next time
+	        }
+
+	        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+	        log.verb('Related object:', redact(JSON.stringify(message)));
+	        this.state.failCount++;
+	        return 'FAILED';
 	      } else {
 	        // other error
 	        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -593,9 +593,9 @@
 	        if (isJob) break; // break without stopping if this is part of a job
 	        this.state.running = false;
 	      }
-	      
+
 	      // wait before next page (fix search page not updating fast enough)
-	      log.verb(`Waiting ${(this.options.searchDelay/1000).toFixed(2)}s before next page...`);
+	      log.verb(`Waiting ${(this.options.searchDelay / 1000).toFixed(2)}s before next page...`);
 	      await wait(this.options.searchDelay);
 
 	    } while (this.state.running);
@@ -691,7 +691,7 @@
 	      if (resp.status === 429) {
 	        let w = (await resp.json()).retry_after * 1000;
 	        w = w || this.stats.searchDelay; // Fix retry_after 0
-	        
+
 	        this.stats.throttledCount++;
 	        this.stats.throttledTotalTime += w;
 	        this.stats.searchDelay += w; // increase delay
@@ -702,7 +702,7 @@
 
 	        await wait(w * 2);
 	        return await this.search();
-	      } 
+	      }
 	      else {
 	        this.state.running = false;
 	        log.error(`Error searching messages, API responded with status ${resp.status}!\n`, await resp.json());
@@ -728,7 +728,7 @@
 	    // we can only delete some types of messages, system messages are not deletable.
 	    let messagesToDelete = discoveredMessages;
 	    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
-	    messagesToDelete = messagesToDelete.filter(msg =>  msg.pinned ? this.options.includePinned : true);
+	    messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
 	    // custom filter of messages
 	    try {
@@ -754,10 +754,10 @@
 
 	      log.debug(
 	        // `${((this.state.delCount + 1) / this.state.grandTotal * 100).toFixed(2)}%`,
-	        `[${this.state.delCount + 1}/${this.state.grandTotal}] `+
-	        `<sup>${new Date(message.timestamp).toLocaleString()}</sup> `+
-	        `<b>${redact(message.author.username + '#' + message.author.discriminator)}</b>`+
-	        `: <i>${redact(message.content).replace(/\n/g, '↵')}</i>`+
+	        `[${this.state.delCount + 1}/${this.state.grandTotal}] ` +
+	        `<sup>${new Date(message.timestamp).toLocaleString()}</sup> ` +
+	        `<b>${redact(message.author.username + '#' + message.author.discriminator)}</b>` +
+	        `: <i>${redact(message.content).replace(/\n/g, '↵')}</i>` +
 	        (message.attachments.length ? redact(JSON.stringify(message.attachments)) : ''),
 	        `<sup>{ID:${redact(message.id)}}</sup>`
 	      );
@@ -815,29 +815,28 @@
 	        await wait(w * 2);
 	        return 'RETRY';
 	      } else {
+	        const body = await resp.text();
 
-			const body = await resp.text();
+	        try {
+	          const r = JSON.parse(body);
 
-			try {
-				const r = JSON.parse(body);
+	          if (resp.status === 400 && r.code === 50083) {
+	            // 400 can happen if the thread is archived (code=50083)
+	            // in this case we need to "skip" this message from the next search
+	            // otherwise it will come up again in the next page (and fail to delete again)
+	            log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
+	            this.state.offset++;
+	            this.state.failCount++;
+	            return 'FAIL_SKIP'; // Failed but we will skip it next time
+	          }
 
-				if (resp.status === 400 && r.code === 50083){
-				  // 400 can happen if the thread is archived (code=50083)
-				  // in this case we need to "skip" this message from the next search
-				  // otherwise it will come up again in the next page (and fail to delete again)
-				  log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
-				  this.state.offset++;
-				  this.state.failCount++;
-				  return 'FAIL_SKIP' ; // Failed but we will skip it next time
-				}
-	
-				log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
-				log.verb('Related object:', redact(JSON.stringify(message)));
-				this.state.failCount++;
-				return 'FAILED';
-			} catch (e){
-				log.error(`Fail to parse JSON. API responded with status ${resp.status}!`, body);
-			}
+	          log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+	          log.verb('Related object:', redact(JSON.stringify(message)));
+	          this.state.failCount++;
+	          return 'FAILED';
+	        } catch (e) {
+	          log.error(`Fail to parse JSON. API responded with status ${resp.status}!`, body);
+	        }
 	      }
 	    }
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -814,23 +814,19 @@
 	        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 	        await wait(w * 2);
 	        return 'RETRY';
-	      } else if (resp.status === 400){
-	        // 400 can happen if the thread is archived (code=50083)
-	        // in this case we need to "skip" this message from the next search
-	        // otherwise it will come up again in the next page (and fail to delete again)
-	        (await resp.json()).code;
-	        if (code === 50083){
-	          log.warn(`Error deleting message (Thread is archived). Will increment offset so we don't search this in the next page...`);
-	          this.state.offset +=1 ;
+	      } else {
+	        const r = await resp.json();
+
+	        if (resp.status === 400 && r.code === 50083){
+	          // 400 can happen if the thread is archived (code=50083)
+	          // in this case we need to "skip" this message from the next search
+	          // otherwise it will come up again in the next page (and fail to delete again)
+	          log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
+	          this.state.offset++;
+	          this.state.failCount++;
 	          return 'FAIL_SKIP' ; // Failed but we will skip it next time
 	        }
 
-	        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
-	        log.verb('Related object:', redact(JSON.stringify(message)));
-	        this.state.failCount++;
-	        return 'FAILED';
-	      } else {
-	        // other error
 	        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
 	        log.verb('Related object:', redact(JSON.stringify(message)));
 	        this.state.failCount++;

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -412,7 +412,7 @@ class UndiscordCore {
             return 'FAIL_SKIP'; // Failed but we will skip it next time
           }
 
-          log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+          log.error(`Error deleting message, API responded with status ${resp.status}!`, r);
           log.verb('Related object:', redact(JSON.stringify(message)));
           this.state.failCount++;
           return 'FAILED';

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -403,8 +403,8 @@ class UndiscordCore {
           // 400 can happen if the thread is archived (code=50083)
           // in this case we need to "skip" this message from the next search
           // otherwise it will come up again in the next page (and fail to delete again)
-          log.warn(`Error deleting message (Thread is archived). Will increment offset so we don't search this in the next page...`);
-          this.state.offset ++;
+          log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
+          this.state.offset++;
           this.state.failCount++;
           return 'FAIL_SKIP' ; // Failed but we will skip it next time
         }

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -175,9 +175,9 @@ class UndiscordCore {
         if (isJob) break; // break without stopping if this is part of a job
         this.state.running = false;
       }
-      
+
       // wait before next page (fix search page not updating fast enough)
-      log.verb(`Waiting ${(this.options.searchDelay/1000).toFixed(2)}s before next page...`);
+      log.verb(`Waiting ${(this.options.searchDelay / 1000).toFixed(2)}s before next page...`);
       await wait(this.options.searchDelay);
 
     } while (this.state.running);
@@ -273,7 +273,7 @@ class UndiscordCore {
       if (resp.status === 429) {
         let w = (await resp.json()).retry_after * 1000;
         w = w || this.stats.searchDelay; // Fix retry_after 0
-        
+
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
         this.stats.searchDelay += w; // increase delay
@@ -284,7 +284,7 @@ class UndiscordCore {
 
         await wait(w * 2);
         return await this.search();
-      } 
+      }
       else {
         this.state.running = false;
         log.error(`Error searching messages, API responded with status ${resp.status}!\n`, await resp.json());
@@ -310,7 +310,7 @@ class UndiscordCore {
     // we can only delete some types of messages, system messages are not deletable.
     let messagesToDelete = discoveredMessages;
     messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
-    messagesToDelete = messagesToDelete.filter(msg =>  msg.pinned ? this.options.includePinned : true);
+    messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
     // custom filter of messages
     try {
@@ -336,10 +336,10 @@ class UndiscordCore {
 
       log.debug(
         // `${((this.state.delCount + 1) / this.state.grandTotal * 100).toFixed(2)}%`,
-        `[${this.state.delCount + 1}/${this.state.grandTotal}] `+
-        `<sup>${new Date(message.timestamp).toLocaleString()}</sup> `+
-        `<b>${redact(message.author.username + '#' + message.author.discriminator)}</b>`+
-        `: <i>${redact(message.content).replace(/\n/g, '↵')}</i>`+
+        `[${this.state.delCount + 1}/${this.state.grandTotal}] ` +
+        `<sup>${new Date(message.timestamp).toLocaleString()}</sup> ` +
+        `<b>${redact(message.author.username + '#' + message.author.discriminator)}</b>` +
+        `: <i>${redact(message.content).replace(/\n/g, '↵')}</i>` +
         (message.attachments.length ? redact(JSON.stringify(message.attachments)) : ''),
         `<sup>{ID:${redact(message.id)}}</sup>`
       );
@@ -397,22 +397,28 @@ class UndiscordCore {
         await wait(w * 2);
         return 'RETRY';
       } else {
-        const r = await resp.json();
+        const body = await resp.text();
 
-        if (resp.status === 400 && r.code === 50083){
-          // 400 can happen if the thread is archived (code=50083)
-          // in this case we need to "skip" this message from the next search
-          // otherwise it will come up again in the next page (and fail to delete again)
-          log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
-          this.state.offset++;
+        try {
+          const r = JSON.parse(body);
+
+          if (resp.status === 400 && r.code === 50083) {
+            // 400 can happen if the thread is archived (code=50083)
+            // in this case we need to "skip" this message from the next search
+            // otherwise it will come up again in the next page (and fail to delete again)
+            log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
+            this.state.offset++;
+            this.state.failCount++;
+            return 'FAIL_SKIP'; // Failed but we will skip it next time
+          }
+
+          log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+          log.verb('Related object:', redact(JSON.stringify(message)));
           this.state.failCount++;
-          return 'FAIL_SKIP' ; // Failed but we will skip it next time
+          return 'FAILED';
+        } catch (e) {
+          log.error(`Fail to parse JSON. API responded with status ${resp.status}!`, body);
         }
-
-        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
-        log.verb('Related object:', redact(JSON.stringify(message)));
-        this.state.failCount++;
-        return 'FAILED';
       }
     }
 

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -396,6 +396,21 @@ class UndiscordCore {
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);
         await wait(w * 2);
         return 'RETRY';
+      } else if (resp.status === 400){
+        // 400 can happen if the thread is archived (code=50083)
+        // in this case we need to "skip" this message from the next search
+        // otherwise it will come up again in the next page (and fail to delete again)
+        const c = (await resp.json()).code;
+        if (code === 50083){
+          log.warn(`Error deleting message (Thread is archived). Will increment offset so we don't search this in the next page...`);
+          this.state.offset +=1 ;
+          return 'FAIL_SKIP' ; // Failed but we will skip it next time
+        }
+
+        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+        log.verb('Related object:', redact(JSON.stringify(message)));
+        this.state.failCount++;
+        return 'FAILED';
       } else {
         // other error
         log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());


### PR DESCRIPTION
Currently, archived threads are a big problem: We fail to delete messages in an archived thread. This itself could be seen as a problem, but the bigger problem (IMO), is that these messages *keep coming up* when searching new pages, since they are still returned by the search call! This is a major problem when the number of archived messages hits 25, since a new page will return all archived messages, and no progress can be made.

This MR implements a kind of patch - if we fail to delete a message, and the reason is that the thread is **archived** , then we increment the offset. 

This allows the fetch of the next page to skip these archived messages from the search results, allowing the overall deletion to make further progress.

### Other MRs

https://github.com/victornpb/undiscord/pull/457 -> This hack fix doesn't help much, since the next search will yield these messages again.

https://github.com/victornpb/undiscord/pull/393 -> This is arguable more efficient, but has a lot of changes, so may take more time to review merge. In the meantime a patch to at least allow further progress on non-archived messages could be useful to some.