### PR TITLE
Do not adjust delay if retry_after < delay

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -390,8 +390,11 @@ class UndiscordCore {
         const w = (await resp.json()).retry_after * 1000;
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
-        this.options.deleteDelay = w; // increase delay
-        log.warn(`Being rate limited by the API for ${w}ms! Adjusted delete delay to ${this.options.deleteDelay}ms.`);
+        log.warn(`Being rate limited by the API for ${w}ms!`);
+        if (this.options.deleteDelay < w) {
+          this.options.deleteDelay = w; // increase delay
+          log.warn(`Adjusted delete delay to ${this.options.deleteDelay}ms.`);
+        }
         this.printStats();
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);
         await wait(w * 2);


### PR DESCRIPTION
As it stands, it appears that the delete delay could be lowered when that may have not been the intention (the comment on the line says `// increase delay`). This PR adds a check before adjusting the delete delay such that it will only ever increase.

Possible issues:
* If the user starts the deletion process and leaves it unattended, a long retry_after response could unexpectedly cripple the deletion speed without the possibility of the delay decreasing to a more sane value.

Perhaps it is time to algorithmically discover the rate limit? #386