### PR TITLE
Unarchive thread to delete messages

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -727,7 +727,7 @@
 
 	    // we can only delete some types of messages, system messages are not deletable.
 	    let messagesToDelete = discoveredMessages;
-	    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
+	    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 20));
 	    messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
 	    // custom filter of messages

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -822,9 +822,17 @@
 
 	          if (resp.status === 400 && r.code === 50083) {
 	            // 400 can happen if the thread is archived (code=50083)
+	            // we can try and unarchive the thread, if we unarchive successfully,
+	            // we can retry the delete.
+	            const unarchiveResult = await this.unarchiveThread(message.channel_id);
+	            if (unarchiveResult === 'UNARCHIVE_SUCCESS'){
+	              return 'RETRY';
+	            }
+
+	            // Failed to unarchive, so we cannot delete this message.
 	            // in this case we need to "skip" this message from the next search
 	            // otherwise it will come up again in the next page (and fail to delete again)
-	            log.warn('Error deleting message (Thread is archived). Will increment offset so we don\'t search this in the next page...');
+	            log.warn('Error deleting message (Thread is archived - failed to unarchive). Will increment offset so we don\'t search this in the next page...');
 	            this.state.offset++;
 	            this.state.failCount++;
 	            return 'FAIL_SKIP'; // Failed but we will skip it next time
@@ -842,6 +850,52 @@
 
 	    this.state.delCount++;
 	    return 'OK';
+	  }
+
+	  async unarchiveThread(threadId){
+	    const THREAD_UNARCHIVE_URL = `https://discord.com/api/v9/channels/${threadId}`;
+	    let resp;
+	    try {
+	      this.beforeRequest();
+	      resp = await fetch(THREAD_UNARCHIVE_URL, {
+	        body: {
+	          archived: false
+	        },
+	        method: 'PATCH',
+	        headers: {
+	          'Authorization': this.options.authToken,
+	        },
+	      });
+	      this.afterRequest();
+	    } catch (err) {
+	      // no response error (e.g. network error)
+	      log.error('Unarchive request throwed an error:', err);
+	      return 'UNARCHIVE_FAILED';
+	    }
+
+	    if(!resp.ok){
+	      const body = await resp.text();
+
+	      try {
+	        const r = JSON.parse(body);
+
+	        if (resp.status === 403 && r.code === 160005){
+	          // 403 happens if the thread is locked, i.e. we don't have permission
+	          // to unarchive it
+	          log.warn(`Error unarchiving thread: Thread is locked`);
+	          return `THREAD_LOCKED`;
+	        }
+
+	        log.error(`Error unarchiving thread. API responded with status ${resp.status}!`, r);
+	      } catch (e){
+	        log.error(`Failed to parse JSON. API responses with status ${resp.status}!`, body);
+	      }
+
+	      return `UNARCHIVE_FAILED`;
+	    }
+
+	    log.info(`Unarchived thread successfully!`);
+	    return `UNARCHIVE_SUCCESS`;
 	  }
 
 	  #beforeTs = 0; // used to calculate latency

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -858,11 +858,12 @@
 	    try {
 	      this.beforeRequest();
 	      resp = await fetch(THREAD_UNARCHIVE_URL, {
-	        body: {
+	        body: JSON.stringify({
 	          archived: false
-	        },
+	        }),
 	        method: 'PATCH',
 	        headers: {
+	          'Content-Type': 'application/json',
 	          'Authorization': this.options.authToken,
 	        },
 	      });

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -309,7 +309,7 @@ class UndiscordCore {
 
     // we can only delete some types of messages, system messages are not deletable.
     let messagesToDelete = discoveredMessages;
-    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
+    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 20));
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
     // custom filter of messages

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -440,9 +440,9 @@ class UndiscordCore {
     try {
       this.beforeRequest();
       resp = await fetch(THREAD_UNARCHIVE_URL, {
-        body: {
+        body: JSON.stringify({
           archived: false
-        },
+        }),
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -445,6 +445,7 @@ class UndiscordCore {
         },
         method: 'PATCH',
         headers: {
+          'Content-Type': 'application/json',
           'Authorization': this.options.authToken,
         },
       });


### PR DESCRIPTION
Currently, if a thread is archived, we just skip those messages. Instead, we can try and unarchive the thread, then delete messages (this is what discord does if you right-click & delete a message in an archived thread - first unarchive, then delete).

Since the while loop already attempts twice, if we fail due to archived, we can:

1. Attempt to unarchive
2. If unarchive successfully, return `RETRY` , so caller fn will try and delete again
3. If fail to unarchive, skip (existing logic).

This can help people delete more messages.

Additionally, while implementing this I found a bug in system messages - Thread started messages (type `21`) are not deletable (as per Discord, see: https://discord.com/developers/docs/resources/channel#message-object-message-types)

Updated the `filter` logic to be `<=20` so 21 is not counted.