### PR TITLE
Stop attempting to delete CHAT_INPUT_COMMAND (Type 20) messages + Adjust delete delay after ratelimit to compensate ontop of current delay

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -276,7 +276,7 @@ class UndiscordCore {
 
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
-        this.stats.searchDelay += w; // increase delay
+        this.stats.searchDelay += this.stats.searchDelay + w; // increase delay
         w = this.stats.searchDelay;
         log.warn(`Being rate limited by the API for ${w}ms! Increasing search delay...`);
         this.printStats();
@@ -309,7 +309,7 @@ class UndiscordCore {
 
     // we can only delete some types of messages, system messages are not deletable.
     let messagesToDelete = discoveredMessages;
-    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
+    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 19) || msg.type === 21);
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
     // custom filter of messages


### PR DESCRIPTION
Undiscord attempts to delete Non-Ethereal Slash Commands (Type 20) due to blanket checking for System Messages with (msg.type >= 6 && msg.type <= 21).

This also adjusts so the ratelimit duration is added on top of the current delete delay, which will in worst case scenarios bump the delay to 1700 (but will avoid almost every ratelimit thereafter, tested with a 4000+ job archive deletion).