### PR TITLE
Workaround for slow search index refreshing & more

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -398,6 +398,8 @@
                 <span class="spacer"></span>
                 <label>
                     <input id="trimLog" type="checkbox" checked> Trim log
+                </label>
+                <label>
                     <input id="autoScroll" type="checkbox" checked> Auto scroll
                 </label>
                 <div class="resize-handle"></div>

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -705,8 +705,8 @@
 
 	    // not indexed yet
 	    if (resp.status === 202) {
-	      let w = (await resp.json()).retry_after * 1000;
-	      w = w || this.stats.searchDelay; // Fix retry_after 0
+	      let w = (await resp.json()).retry_after;
+	      w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
 	      this.stats.throttledCount++;
 	      this.stats.throttledTotalTime += w;
 	      log.warn(`This channel isn't indexed yet. Waiting ${w}ms for discord to index it...`);
@@ -717,14 +717,12 @@
 	    if (!resp.ok) {
 	      // searching messages too fast
 	      if (resp.status === 429) {
-	        let w = (await resp.json()).retry_after * 1000;
-	        w = w || this.stats.searchDelay; // Fix retry_after 0
+	        let w = (await resp.json()).retry_after;
+	        w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
 
 	        this.stats.throttledCount++;
 	        this.stats.throttledTotalTime += w;
-	        this.stats.searchDelay += w; // increase delay
-	        w = this.stats.searchDelay;
-	        log.warn(`Being rate limited by the API for ${w}ms! Increasing search delay...`);
+	        log.warn(`Being rate limited by the API for ${w}ms!`);
 	        this.printStats();
 	        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 
@@ -833,11 +831,11 @@
 	    if (!resp.ok) {
 	      if (resp.status === 429) {
 	        // deleting messages too fast
-	        const w = (await resp.json()).retry_after * 1000;
+	        let w = (await resp.json()).retry_after;
+	        w = !isNaN(w) ? w * 1000 : this.stats.deleteDelay;
 	        this.stats.throttledCount++;
 	        this.stats.throttledTotalTime += w;
-	        this.options.deleteDelay = w; // increase delay
-	        log.warn(`Being rate limited by the API for ${w}ms! Adjusted delete delay to ${this.options.deleteDelay}ms.`);
+	        log.warn(`Being rate limited by the API for ${w}ms!`);
 	        this.printStats();
 	        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 	        await wait(w * 2);

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -397,6 +397,7 @@
                 <div id="progressPercent"></div>
                 <span class="spacer"></span>
                 <label>
+                    <input id="trimLog" type="checkbox" checked> Trim log
                     <input id="autoScroll" type="checkbox" checked> Auto scroll
                 </label>
                 <div class="resize-handle"></div>
@@ -1303,6 +1304,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  undiscordBtn: null,
 	  logArea: null,
 	  autoScroll: null,
+	  trimLog: null,
 
 	  // progress handler
 	  progressMain: null,
@@ -1363,6 +1365,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  // cached elements
 	  ui.logArea = $('#logArea');
 	  ui.autoScroll = $('#autoScroll');
+	  ui.trimLog = $('#trimLog');
 	  ui.progressMain = $('#progressBar');
 	  ui.progressIcon = ui.undiscordBtn.querySelector('progress');
 	  ui.percent = $('#progressPercent');
@@ -1456,6 +1459,17 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 
 	function printLog(type = '', args) {
 	  ui.logArea.insertAdjacentHTML('beforeend', `<div class="log log-${type}">${Array.from(args).map(o => typeof o === 'object' ? JSON.stringify(o, o instanceof Error && Object.getOwnPropertyNames(o)) : o).join('\t')}</div>`);
+
+	  if (ui.trimLog.checked) {
+	    const maxLogEntries = 500;
+	    const logEntries = ui.logArea.querySelectorAll('.log');
+	    if (logEntries.length > maxLogEntries) {
+	      for (let i = 0; i < (logEntries.length - maxLogEntries); i++) {
+	        logEntries[i].remove();
+	      }
+	    }
+	  }
+
 	  if (ui.autoScroll.checked) ui.logArea.querySelector('div:last-child').scrollIntoView(false);
 	  if (type==='error') console.error(PREFIX, ...Array.from(args));
 	}

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -486,6 +486,7 @@
 	    pattern: null, // Only delete messages that match the regex (insensitive)
 	    searchDelay: null, // Delay each time we fetch for more messages
 	    deleteDelay: null, // Delay between each delete operation
+	    rateLimitPrevention: null, // Whether rate limit prevention is enabled or not
 	    maxAttempt: 2, // Attempts to delete a single message if it fails
 	    askForConfirmation: true,
 	  };
@@ -976,7 +977,7 @@
 	  async beforeRequest() {
 	    this.#requestLog.push(Date.now());
 	    this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
-	    if (ui.rateLimitPrevention.checked) {
+	    if (this.options.rateLimitPrevention) {
 	      let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
 	      for (let [maxRequests, timePeriod] of rateLimits) {
 	        if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
@@ -1371,7 +1372,6 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  logArea: null,
 	  autoScroll: null,
 	  trimLog: null,
-	  rateLimitPrevention: null,
 
 	  // progress handler
 	  progressMain: null,
@@ -1436,7 +1436,6 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  ui.progressMain = $('#progressBar');
 	  ui.progressIcon = ui.undiscordBtn.querySelector('progress');
 	  ui.percent = $('#progressPercent');
-	  ui.rateLimitPrevention = $('#rateLimitPrevention');
 
 	  // register event listeners
 	  $('#hide').onclick = toggleWindow;
@@ -1473,7 +1472,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  };
 	  $('button#getToken').onclick = () => $('input#token').value = fillToken();
 
-	  // sync delays
+	  // sync advanced settings
 	  $('input#searchDelay').onchange = (e) => {
 	    const v = parseInt(e.target.value);
 	    if (v) undiscordCore.options.searchDelay = v;
@@ -1481,6 +1480,9 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  $('input#deleteDelay').onchange = (e) => {
 	    const v = parseInt(e.target.value);
 	    if (v) undiscordCore.options.deleteDelay = v;
+	  };
+	  $('input#rateLimitPrevention').onchange = (e) => {
+	    undiscordCore.options.rateLimitPrevention = e.target.checked ?? false;
 	  };
 
 	  $('input#searchDelay').addEventListener('input', (event) => {
@@ -1623,6 +1625,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  //advanced
 	  const searchDelay = parseInt($('input#searchDelay').value.trim());
 	  const deleteDelay = parseInt($('input#deleteDelay').value.trim());
+	  const rateLimitPrevention = $('input#rateLimitPrevention').checked;
 	 
 	  // token
 	  const authToken = $('input#token').value.trim() || fillToken();
@@ -1652,6 +1655,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	    pattern,
 	    searchDelay,
 	    deleteDelay,
+	    rateLimitPrevention,
 	    // maxAttempt: 2,
 	  };
 	  if (channelIds.length > 1) {

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -350,6 +350,7 @@
                         Use the help link for more information.
                     </div>
                 </fieldset>
+                <label><input id="rateLimitPrevention" type="checkbox" checked>Rate limit prevention</label>
                 <hr>
                 <fieldset>
                     <legend>
@@ -975,14 +976,16 @@
 	  async beforeRequest() {
 	    this.#requestLog.push(Date.now());
 	    this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
-	    let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
-	    for (let [maxRequests, timePeriod] of rateLimits) {
-	      if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
-	        let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
-	        delay = delay * 1.15 + 300; // adding a buffer and additional wait time
-	        log.verb(`Delaying for an extra ${(delay / 1000).toFixed(2)}s to avoid rate limits...`);
-	        await new Promise(resolve => setTimeout(resolve, delay));
-	        break;
+	    if (ui.rateLimitPrevention.checked) {
+	      let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
+	      for (let [maxRequests, timePeriod] of rateLimits) {
+	        if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
+	          let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
+	          delay = delay * 1.15 + 300; // adding a buffer and additional wait time
+	          log.verb(`Delaying for an extra ${(delay / 1000).toFixed(2)}s to avoid rate limits...`);
+	          await new Promise(resolve => setTimeout(resolve, delay));
+	          break;
+	        }
 	      }
 	    }
 	    this.#beforeTs = Date.now();
@@ -1368,6 +1371,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  logArea: null,
 	  autoScroll: null,
 	  trimLog: null,
+	  rateLimitPrevention: null,
 
 	  // progress handler
 	  progressMain: null,
@@ -1432,6 +1436,7 @@ body.undiscord-pick-message.after [id^="message-content-"]:hover::after {
 	  ui.progressMain = $('#progressBar');
 	  ui.progressIcon = ui.undiscordBtn.querySelector('progress');
 	  ui.percent = $('#progressPercent');
+	  ui.rateLimitPrevention = $('#rateLimitPrevention');
 
 	  // register event listeners
 	  $('#hide').onclick = toggleWindow;

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -444,7 +444,7 @@
 	    worker.addEventListener('message', function(e) {
 	      if (e.data === 'done') {
 	        let delay = Date.now() - start - ms;
-	        if(delay > 100) log.warn(`This action was delayed ${delay}ms more than it should've, make sure you don't have too many tabs open!`);
+	        if(delay > 100) console.warn(`This action was delayed ${delay}ms more than it should've, make sure you don't have too many tabs open!`);
 	        resolve();
 	        worker.terminate();
 	      }

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -678,7 +678,7 @@
 
 	    let resp;
 	    try {
-	      this.beforeRequest();
+	      await this.beforeRequest();
 	      resp = await fetch(API_SEARCH_URL + 'search?' + queryString([
 	        ['author_id', this.options.authorId || undefined],
 	        ['channel_id', (this.options.guildId !== '@me' ? this.options.channelId : undefined) || undefined],
@@ -812,7 +812,7 @@
 	    const API_DELETE_URL = `https://discord.com/api/v9/channels/${message.channel_id}/messages/${message.id}`;
 	    let resp;
 	    try {
-	      this.beforeRequest();
+	      await this.beforeRequest();
 	      resp = await fetch(API_DELETE_URL, {
 	        method: 'DELETE',
 	        headers: {
@@ -871,7 +871,20 @@
 	  }
 
 	  #beforeTs = 0; // used to calculate latency
-	  beforeRequest() {
+	  #requestLog = []; // used to add any extra delay
+	  async beforeRequest() {
+	    this.#requestLog.push(Date.now());
+	    this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
+	    let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
+	    for(let [maxRequests, timePeriod] of rateLimits){
+	      if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
+	        let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
+	        delay = delay * 1.15 + 300; // adding a buffer and additional wait time
+	        log.verb(`Delaying for an extra ${(delay / 1000).toFixed(2)}s to avoid rate limits...`);
+	        await new Promise(resolve => setTimeout(resolve, delay));
+	        break;
+	      }
+	    }
 	    this.#beforeTs = Date.now();
 	  }
 	  afterRequest() {

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -681,7 +681,7 @@
 
 	  /** Calculate the estimated time remaining based on the current stats */
 	  calcEtr() {
-	    this.stats.etr = (this.options.searchDelay * Math.round(this.state.grandTotal / 25)) + ((this.options.deleteDelay + this.stats.avgPing) * this.state.grandTotal);
+	    this.stats.etr = (this.options.searchDelay + this.stats.avgPing) * Math.round((this.state.grandTotal - this.state.delCount) / 25) + (this.options.deleteDelay + this.stats.avgPing) * (this.state.grandTotal - this.state.delCount);
 	  }
 
 	  /** As for confirmation in the beggining process */

--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -78,6 +78,9 @@
                         After requesting your data from discord, you can import it here.<br>
                         Select the "messages/index.json" file from the discord archive.
                     </div>
+                    <div class="sectionDescription">
+                        <label><input id="includeServers" type="checkbox">Include servers</label>
+                    </div>
                 </fieldset>
             </details>
             <hr>

--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -248,6 +248,8 @@
                 <span class="spacer"></span>
                 <label>
                     <input id="autoScroll" type="checkbox" checked> Auto scroll
+                </label>
+                <label>
                     <input id="trimLog" type="checkbox" checked> Trim log
                 </label>
                 <div class="resize-handle"></div>

--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -248,6 +248,7 @@
                 <span class="spacer"></span>
                 <label>
                     <input id="autoScroll" type="checkbox" checked> Auto scroll
+                    <input id="trimLog" type="checkbox" checked> Trim log
                 </label>
                 <div class="resize-handle"></div>
             </div>

--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -101,7 +101,7 @@
                         <label><input id="hasFile" type="checkbox">has: file</label>
                     </div>
                     <div class="sectionDescription">
-                        <label><input id="includePinned" type="checkbox">Include pinned</label>
+                        <label><input id="includePinned" type="checkbox" checked>Include pinned</label>
                     </div>
                 </fieldset>
                 <hr>
@@ -178,7 +178,7 @@
                         <a href="{{WIKI}}/delay" title="Help" target="_blank" rel="noopener noreferrer">help</a>
                     </legend>
                     <div class="input-wrapper">
-                        <input id="searchDelay" type="range" value="30000" step="100" min="100" max="60000">
+                        <input id="searchDelay" type="range" value="1400" step="100" min="100" max="60000">
                         <div id="searchDelayValue"></div>
                     </div>
                 </fieldset>
@@ -188,7 +188,7 @@
                         <a href="{{WIKI}}/delay" title="Help" target="_blank" rel="noopener noreferrer">help</a>
                     </legend>
                     <div class="input-wrapper">
-                        <input id="deleteDelay" type="range" value="1000" step="50" min="50" max="10000">
+                        <input id="deleteDelay" type="range" value="1400" step="50" min="50" max="10000">
                         <div id="deleteDelayValue"></div>
                     </div>
                     <br>

--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -200,6 +200,7 @@
                         Use the help link for more information.
                     </div>
                 </fieldset>
+                <label><input id="rateLimitPrevention" type="checkbox" checked>Rate limit prevention</label>
                 <hr>
                 <fieldset>
                     <legend>

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -230,7 +230,7 @@ class UndiscordCore {
 
   /** Calculate the estimated time remaining based on the current stats */
   calcEtr() {
-    this.stats.etr = (this.options.searchDelay * Math.round(this.state.grandTotal / 25)) + ((this.options.deleteDelay + this.stats.avgPing) * this.state.grandTotal);
+    this.stats.etr = (this.options.searchDelay + this.stats.avgPing) * Math.round((this.state.grandTotal - this.state.delCount) / 25) + (this.options.deleteDelay + this.stats.avgPing) * (this.state.grandTotal - this.state.delCount);
   }
 
   /** As for confirmation in the beggining process */

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -523,14 +523,16 @@ class UndiscordCore {
   async beforeRequest() {
     this.#requestLog.push(Date.now());
     this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
-    let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
-    for (let [maxRequests, timePeriod] of rateLimits) {
-      if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
-        let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
-        delay = delay * 1.15 + 300; // adding a buffer and additional wait time
-        log.verb(`Delaying for an extra ${(delay / 1000).toFixed(2)}s to avoid rate limits...`);
-        await new Promise(resolve => setTimeout(resolve, delay));
-        break;
+    if (ui.rateLimitPrevention.checked) {
+      let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
+      for (let [maxRequests, timePeriod] of rateLimits) {
+        if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
+          let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
+          delay = delay * 1.15 + 300; // adding a buffer and additional wait time
+          log.verb(`Delaying for an extra ${(delay / 1000).toFixed(2)}s to avoid rate limits...`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          break;
+        }
       }
     }
     this.#beforeTs = Date.now();

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -33,6 +33,7 @@ class UndiscordCore {
     pattern: null, // Only delete messages that match the regex (insensitive)
     searchDelay: null, // Delay each time we fetch for more messages
     deleteDelay: null, // Delay between each delete operation
+    rateLimitPrevention: null, // Whether rate limit prevention is enabled or not
     maxAttempt: 2, // Attempts to delete a single message if it fails
     askForConfirmation: true,
   };
@@ -523,7 +524,7 @@ class UndiscordCore {
   async beforeRequest() {
     this.#requestLog.push(Date.now());
     this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
-    if (ui.rateLimitPrevention.checked) {
+    if (this.options.rateLimitPrevention) {
       let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
       for (let [maxRequests, timePeriod] of rateLimits) {
         if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -44,6 +44,9 @@ class UndiscordCore {
     offset: {'asc': 0, 'desc': 0},
     iterations: 0,
     sortOrder: 'asc',
+    searchedPages: 0,
+    totalSkippedMessages: 0,
+    startEmptyPages: -1,
 
     _seachResponse: null,
     _messagesToDelete: [],
@@ -73,6 +76,9 @@ class UndiscordCore {
       offset: {'asc': 0, 'desc': 0},
       iterations: 0,
       sortOrder: 'asc',
+      searchedPages: 0,
+      totalSkippedMessages: 0,
+      startEmptyPages: -1,
 
       _seachResponse: null,
       _messagesToDelete: [],
@@ -138,6 +144,7 @@ class UndiscordCore {
       this.state.sortOrder = this.state.sortOrder == 'desc' ? 'asc' : 'desc';
       log.verb(`Set sort order to ${this.state.sortOrder} for this search.`);
       await this.search();
+      this.state.searchedPages++;
 
       // Process results and find which messages should be deleted
       await this.filterResponse();
@@ -151,6 +158,7 @@ class UndiscordCore {
         `offset (desc): ${this.state.offset['desc']}`
       );
       this.printStats();
+      this.state.totalSkippedMessages += this.state._skippedMessages.length;
 
       // Calculate estimated time
       this.calcEtr();
@@ -158,6 +166,7 @@ class UndiscordCore {
 
       // if there are messages to delete, delete them
       if (this.state._messagesToDelete.length > 0) {
+        this.state.startEmptyPages = -1;
 
         if (await this.confirm() === false) {
           this.state.running = false; // break out of a job
@@ -169,16 +178,30 @@ class UndiscordCore {
       else if (this.state._skippedMessages.length > 0) {
         // There are stuff, but nothing to delete (example a page full of system messages)
         // check next page until we see a page with nothing in it (end of results).
+        this.state.startEmptyPages = -1;
+
         const oldOffset = this.state.offset[this.state.sortOrder];
         this.state.offset[this.state.sortOrder] += this.state._skippedMessages.length;
         log.verb('There\'s nothing we can delete on this page, checking next page...');
         log.verb(`Skipped ${this.state._skippedMessages.length} out of ${this.state._seachResponse.messages.length} in this page.`, `(Offset for ${this.state.sortOrder} was ${oldOffset}, ajusted to ${this.state.offset[this.state.sortOrder]})`);
       }
       else {
-        log.verb('Ended because API returned an empty page.');
-        log.verb('[End state]', this.state);
-        if (isJob) break; // break without stopping if this is part of a job
-        this.state.running = false;
+        if (this.state.startEmptyPages == -1) this.state.startEmptyPages = Date.now();
+        // if the first page we are searching is empty
+        // or we've been getting empty page responses for the past 30 seconds (enough for Discord to re-index the pages)
+        // or (deleted messages + failed to delete + total skipped) >= total messages
+        // ONLY THEN proceed with ending the job
+        if (this.state.searchedPages == 1 || (Date.now() - this.state.startEmptyPages) > 30 * 1000 || (this.state.delCount + this.state.failCount + this.state.totalSkippedMessages) >= this.state.grandTotal) {
+          log.verb('Ended because API returned an empty page.');
+          log.verb('[End state]', this.state);
+          if (isJob) break; // break without stopping if this is part of a job
+          this.state.running = false;
+        } else {
+          // wait 10 seconds for Discord to re-index the search page before retrying
+          const waitingTime = 10 * 1000;
+          log.verb(`API returned an empty page, waiting an extra ${(waitingTime / 1000).toFixed(2)}s before searching again...`);
+          await wait(waitingTime);
+        }
       }
 
       // wait before next page (fix search page not updating fast enough)

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -287,8 +287,8 @@ class UndiscordCore {
 
     // not indexed yet
     if (resp.status === 202) {
-      let w = (await resp.json()).retry_after * 1000;
-      w = w || this.stats.searchDelay; // Fix retry_after 0
+      let w = (await resp.json()).retry_after;
+      w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
       this.stats.throttledCount++;
       this.stats.throttledTotalTime += w;
       log.warn(`This channel isn't indexed yet. Waiting ${w}ms for discord to index it...`);
@@ -299,14 +299,12 @@ class UndiscordCore {
     if (!resp.ok) {
       // searching messages too fast
       if (resp.status === 429) {
-        let w = (await resp.json()).retry_after * 1000;
-        w = w || this.stats.searchDelay; // Fix retry_after 0
+        let w = (await resp.json()).retry_after;
+        w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
 
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
-        this.stats.searchDelay += w; // increase delay
-        w = this.stats.searchDelay;
-        log.warn(`Being rate limited by the API for ${w}ms! Increasing search delay...`);
+        log.warn(`Being rate limited by the API for ${w}ms!`);
         this.printStats();
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);
 
@@ -415,11 +413,11 @@ class UndiscordCore {
     if (!resp.ok) {
       if (resp.status === 429) {
         // deleting messages too fast
-        const w = (await resp.json()).retry_after * 1000;
+        let w = (await resp.json()).retry_after;
+        w = !isNaN(w) ? w * 1000 : this.stats.searchDelay;
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
-        this.options.deleteDelay = w; // increase delay
-        log.warn(`Being rate limited by the API for ${w}ms! Adjusted delete delay to ${this.options.deleteDelay}ms.`);
+        log.warn(`Being rate limited by the API for ${w}ms!`);
         this.printStats();
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);
         await wait(w * 2);

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -104,12 +104,8 @@ class UndiscordCore {
         ...job, // override with options for that job
       };
 
-      if (this.options.guildId !== '@me' && !this.options.includeServers) {
-        log.verb(`Skipping the channel ${this.options.channelId} as it's a server channel.`);
-      } else {
-        await this.run(true);
-        if (!this.state.running) break;
-      }
+      await this.run(true);
+      if (!this.state.running) break;
 
       log.info('Job ended.', `(${i + 1}/${queue.length})`);
       this.resetState();
@@ -129,6 +125,18 @@ class UndiscordCore {
     this.stats.startTime = new Date();
 
     log.success(`\nStarted at ${this.stats.startTime.toLocaleString()}`);
+    if (this.onStart) this.onStart(this.state, this.stats);
+
+    if (!this.options.guildId) {
+      log.verb('Fetching channel info...');
+      await this.fetchChannelInfo();
+    }
+    if (!this.options.guildId) return; // message is handled in fetchChannelInfo
+    if (isJob && this.options.guildId !== '@me' && !this.options.includeServers) {
+      log.warn(`Skipping the channel ${this.options.channelId} as it's a server channel.`);
+      return;
+    }
+
     log.debug(
       `authorId = "${redact(this.options.authorId)}"`,
       `guildId = "${redact(this.options.guildId)}"`,
@@ -138,8 +146,6 @@ class UndiscordCore {
       `hasLink = ${!!this.options.hasLink}`,
       `hasFile = ${!!this.options.hasFile}`,
     );
-
-    if (this.onStart) this.onStart(this.state, this.stats);
 
     do {
       this.state.iterations++;
@@ -256,6 +262,60 @@ class UndiscordCore {
       this.options.askForConfirmation = false; // do not ask for confirmation again on the next request
       return true;
     }
+  }
+
+  async fetchChannelInfo() {
+    let API_CHANNEL_URL = `https://discord.com/api/v9/channels/${this.options.channelId}`;
+
+    let resp;
+    try {
+      await this.beforeRequest();
+      resp = await fetch(API_CHANNEL_URL, {
+        headers: {
+          'Authorization': this.options.authToken,
+        }
+      });
+      this.afterRequest();
+    } catch (err) {
+      this.state.running = false;
+      log.error('Channel request threw an error:', err);
+      throw err;
+    }
+
+    // not indexed yet
+    if (resp.status === 202) {
+      let w = (await resp.json()).retry_after;
+      w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
+      this.stats.throttledCount++;
+      this.stats.throttledTotalTime += w;
+      log.warn(`This channel isn't indexed yet. Waiting ${w}ms for discord to index it...`);
+      await wait(w);
+      return await this.fetchChannelInfo();
+    }
+
+    if (!resp.ok) {
+      // rate limit
+      if (resp.status === 429) {
+        let w = (await resp.json()).retry_after;
+        w = !isNaN(w) ? w * 1000 : this.stats.searchDelay; // Fix retry_after 0
+
+        this.stats.throttledCount++;
+        this.stats.throttledTotalTime += w;
+        log.warn(`Being rate limited by the API for ${w}ms!`);
+        this.printStats();
+        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
+
+        await wait(w * 2);
+        return await this.fetchChannelInfo();
+      }
+      else {
+        log.error(`Error fetching the channel, API responded with status ${resp.status}!\n`, await resp.json());
+        return {};
+      }
+    }
+    const data = await resp.json();
+    this.options.guildId = data.guild_id ?? '@me';
+    return data;
   }
 
   async search() {
@@ -464,7 +524,7 @@ class UndiscordCore {
     this.#requestLog.push(Date.now());
     this.#requestLog = this.#requestLog.filter(timestamp => (Date.now() - timestamp) < 60 * 1000);
     let rateLimits = [[45, 60], [4, 5]]; // todo: confirm, testing shows these are right
-    for(let [maxRequests, timePeriod] of rateLimits){
+    for (let [maxRequests, timePeriod] of rateLimits) {
       if (this.#requestLog.length >= maxRequests && (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]) < timePeriod * 1000) {
         let delay = timePeriod * 1000 - (Date.now() - this.#requestLog[this.#requestLog.length - maxRequests]);
         delay = delay * 1.15 + 300; // adding a buffer and additional wait time

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -33,7 +33,6 @@ const ui = {
   logArea: null,
   autoScroll: null,
   trimLog: null,
-  rateLimitPrevention: null,
 
   // progress handler
   progressMain: null,
@@ -98,7 +97,6 @@ function initUI() {
   ui.progressMain = $('#progressBar');
   ui.progressIcon = ui.undiscordBtn.querySelector('progress');
   ui.percent = $('#progressPercent');
-  ui.rateLimitPrevention = $('#rateLimitPrevention');
 
   // register event listeners
   $('#hide').onclick = toggleWindow;
@@ -135,7 +133,7 @@ function initUI() {
   };
   $('button#getToken').onclick = () => $('input#token').value = fillToken();
 
-  // sync delays
+  // sync advanced settings
   $('input#searchDelay').onchange = (e) => {
     const v = parseInt(e.target.value);
     if (v) undiscordCore.options.searchDelay = v;
@@ -143,6 +141,9 @@ function initUI() {
   $('input#deleteDelay').onchange = (e) => {
     const v = parseInt(e.target.value);
     if (v) undiscordCore.options.deleteDelay = v;
+  };
+  $('input#rateLimitPrevention').onchange = (e) => {
+    undiscordCore.options.rateLimitPrevention = e.target.checked ?? false;
   };
 
   $('input#searchDelay').addEventListener('input', (event) => {
@@ -285,6 +286,7 @@ async function startAction() {
   //advanced
   const searchDelay = parseInt($('input#searchDelay').value.trim());
   const deleteDelay = parseInt($('input#deleteDelay').value.trim());
+  const rateLimitPrevention = $('input#rateLimitPrevention').checked;
  
   // token
   const authToken = $('input#token').value.trim() || fillToken();
@@ -314,6 +316,7 @@ async function startAction() {
     pattern,
     searchDelay,
     deleteDelay,
+    rateLimitPrevention,
     // maxAttempt: 2,
   };
 

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -161,9 +161,9 @@ function initUI() {
     // Get channel id field to set it later
     const channelIdField = $('input#channelId');
 
-    // Force the guild id to be ourself (@me)
+    // Force the guild id to be 'null' (placeholder value)
     const guildIdField = $('input#guildId');
-    guildIdField.value = '@me';
+    guildIdField.value = 'null';
 
     // Set author id in case its not set already
     $('input#authorId').value = getAuthorId();
@@ -333,7 +333,7 @@ async function startAction() {
   // multiple channels
   else if (channelIds.length > 1) {
     const jobs = channelIds.map(ch => ({
-      guildId: guildId,
+      guildId: null,
       channelId: ch,
     }));
 

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -253,6 +253,8 @@ async function startAction() {
   const guildId = $('input#guildId').value.trim();
   const channelIds = $('input#channelId').value.trim().split(/\s*,\s*/);
   const includeNsfw = $('input#includeNsfw').checked;
+  // wipe archive
+  const includeServers = $('input#includeServers').checked;
   // filter
   const content = $('input#search').value.trim();
   const hasLink = $('input#hasLink').checked;
@@ -292,6 +294,7 @@ async function startAction() {
     hasLink,
     hasFile,
     includeNsfw,
+    includeServers,
     includePinned,
     pattern,
     searchDelay,

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -32,6 +32,7 @@ const ui = {
   undiscordBtn: null,
   logArea: null,
   autoScroll: null,
+  trimLog: null,
 
   // progress handler
   progressMain: null,
@@ -92,6 +93,7 @@ function initUI() {
   // cached elements
   ui.logArea = $('#logArea');
   ui.autoScroll = $('#autoScroll');
+  ui.trimLog = $('#trimLog');
   ui.progressMain = $('#progressBar');
   ui.progressIcon = ui.undiscordBtn.querySelector('progress');
   ui.percent = $('#progressPercent');
@@ -185,6 +187,17 @@ function initUI() {
 
 function printLog(type = '', args) {
   ui.logArea.insertAdjacentHTML('beforeend', `<div class="log log-${type}">${Array.from(args).map(o => typeof o === 'object' ? JSON.stringify(o, o instanceof Error && Object.getOwnPropertyNames(o)) : o).join('\t')}</div>`);
+
+  if (ui.trimLog.checked) {
+    const maxLogEntries = 500;
+    const logEntries = ui.logArea.querySelectorAll('.log');
+    if (logEntries.length > maxLogEntries) {
+      for (let i = 0; i < (logEntries.length - maxLogEntries); i++) {
+        logEntries[i].remove();
+      }
+    }
+  }
+
   if (ui.autoScroll.checked) ui.logArea.querySelector('div:last-child').scrollIntoView(false);
   if (type==='error') console.error(PREFIX, ...Array.from(args));
 }

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -33,6 +33,7 @@ const ui = {
   logArea: null,
   autoScroll: null,
   trimLog: null,
+  rateLimitPrevention: null,
 
   // progress handler
   progressMain: null,
@@ -97,6 +98,7 @@ function initUI() {
   ui.progressMain = $('#progressBar');
   ui.progressIcon = ui.undiscordBtn.querySelector('progress');
   ui.percent = $('#progressPercent');
+  ui.rateLimitPrevention = $('#rateLimitPrevention');
 
   // register event listeners
   $('#hide').onclick = toggleWindow;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -12,7 +12,7 @@ const blob = new Blob([workerScript], { type: 'application/javascript' });
 const workerUrl = URL.createObjectURL(blob);
 
 // Helpers
-const wait = ms => {
+export const wait = ms => {
   return new Promise((resolve, reject) => {
     const worker = new Worker(workerUrl);
     let start = Date.now();
@@ -20,7 +20,7 @@ const wait = ms => {
     worker.addEventListener('message', function(e) {
       if (e.data === 'done') {
         let delay = Date.now() - start - ms;
-        if(delay > 100) log.warn(`This action was delayed ${delay}ms more than it should've, make sure you don't have too many tabs open!`);
+        if(delay > 100) console.warn(`This action was delayed ${delay}ms more than it should've, make sure you don't have too many tabs open!`);
         resolve();
         worker.terminate();
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,5 +1,33 @@
+// Web Worker code as a string
+const workerScript = `
+  self.addEventListener('message', function(e) {
+    const ms = e.data;
+    setTimeout(() => {
+      self.postMessage('done');
+    }, ms);
+  });
+`;
+// Create a Blob URL for the Web Worker
+const blob = new Blob([workerScript], { type: 'application/javascript' });
+const workerUrl = URL.createObjectURL(blob);
+
 // Helpers
-export const wait = async ms => new Promise(done => setTimeout(done, ms));
+const wait = ms => {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(workerUrl);
+    let start = Date.now();
+    worker.postMessage(ms);
+    worker.addEventListener('message', function(e) {
+      if (e.data === 'done') {
+        let delay = Date.now() - start - ms;
+        if(delay > 100) log.warn(`This action was delayed ${delay}ms more than it should've, make sure you don't have too many tabs open!`);
+        resolve();
+        worker.terminate();
+      }
+    });
+    worker.addEventListener('error', reject);
+  });
+};
 export const msToHMS = s => `${s / 3.6e6 | 0}h ${(s % 3.6e6) / 6e4 | 0}m ${(s % 6e4) / 1000 | 0}s`;
 export const escapeHTML = html => String(html).replace(/[&<"']/g, m => ({ '&': '&amp;', '<': '&lt;', '"': '&quot;', '\'': '&#039;' })[m]);
 export const redact = str => `<x>${escapeHTML(str)}</x>`;


### PR DESCRIPTION
I want to preface this by saying that I've deleted over 200k messages with these changes in the span of ~7 days and my account hasn't gotten banned. The fastest I've been able to delete messages without any problems was a little less than 1k per 30 minutes.

This PR has the following changes:
- Workaround for Discord's slow search index refreshing: Discord takes ~35s to reload its search pages, we work around this by alternating between ascending and descending sort order on each search.
- Fixed prematurely ending the job when the API returns an empty page: added checks to make sure if this is the case, if not we just wait until Discord updates the index.
- Fixed spamming the log when search gets rate limited & disabled increasing the delays: after getting rate limited once, the delete delay would change to whatever Discord's retry_after was and then it'd be a cycle of getting rate limited and changing the delay again.
- Added rate limit prevention: through trial and error I've found that 45 requests per 60s and 4 requests per 5s are Discord's rate limits for users, this however might need some testing. I've barely had Discord rate limit me with that change while also keeping the program's message deleting speed relatively fast. There is an on/off checkbox for this option.
- Search errors will just return no messages instead of crashing: the job would crash, defeating the purpose of "wipe archive" since it wouldn't be automated.
- Added a button to include servers when using the "wipe archive" option, however "wipe archive" doesn't work with servers yet.
- Workaround for the program getting throttled when being on another tab: browsers make timers run slower to preserve battery and memory, which would make deleting messages slower.
- Added an option for trimming the log: when I had this run overnight, the tab would crash from the log text being too long. I've found that at ~500 lines in the log is when things would start getting laggy.
- Fixed estimated time remaning calculation: it now factors in your ping and the messages deleted so far.
- Wipe archive now supports server channels using the Discord API to fetch the guild id. There is an on/off checkbox for whether to include server channels or not.

I've also changed search delay and delete delay to 1400ms. Through testing, this was the fastest I could go without getting rate limited all the time.