### PR TITLE
Application Commands fix.

### DIFF
--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -103,6 +103,9 @@
                     <div class="sectionDescription">
                         <label><input id="includePinned" type="checkbox">Include pinned</label>
                     </div>
+                    <div class="sectionDescription">
+                        <label><input id="includeApplications" type="checkbox">Include Applications</label>
+                    </div>
                 </fieldset>
                 <hr>
                 <fieldset>

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -311,7 +311,10 @@ class UndiscordCore {
     let messagesToDelete = discoveredMessages;
     messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
-
+    
+    // if the user provided an author.Id, skip all messages that aren't created by the author.Id.
+    // fixes issues with bots & applications hanging the deletion.
+    if (this.options.authorId) messagesToDelete = messagesToDelete.filter(msg => msg.author.id === this.options.authorId);
     // custom filter of messages
     try {
       const regex = new RegExp(this.options.pattern, 'i');

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -316,9 +316,7 @@ class UndiscordCore {
     // if the user provided an author.Id and doesn't wish to include applications, skip all messages that aren't created by the author.Id.
     // fixes issues with bots & applications hanging the deletion
     if (this.options.includeApplications == false) {
-      log.verb("IncludeApplications filter is false. Skipping bots and applications...")
-    }
-    if (this.options.includeApplications == false) {
+      log.verb("Include Applications is false. Skipping bots and applications...")
       messagesToDelete = messagesToDelete.filter(msg => !msg.author.bot);
     }
      // custom filter of messages

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -31,6 +31,7 @@ class UndiscordCore {
     includePinned: null, // Delete messages that are pinned
     pattern: null, // Only delete messages that match the regex (insensitive)
     searchDelay: null, // Delay each time we fetch for more messages
+    includeApplications: null,
     deleteDelay: null, // Delay between each delete operation
     maxAttempt: 2, // Attempts to delete a single message if it fails
     askForConfirmation: true,
@@ -312,10 +313,12 @@ class UndiscordCore {
     messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
     
-    // if the user provided an author.Id, skip all messages that aren't created by the author.Id.
+    // if the user provided an author.Id and doesn't wish to include applications, skip all messages that aren't created by the author.Id.
     // fixes issues with bots & applications hanging the deletion.
-    if (this.options.authorId) messagesToDelete = messagesToDelete.filter(msg => msg.author.id === this.options.authorId);
-    // custom filter of messages
+    if (!this.options.includeApplications) {
+        if (this.options.authorId) messagesToDelete = messagesToDelete.filter(msg => msg.author.id === this.options.authorId);
+    }
+     // custom filter of messages
     try {
       const regex = new RegExp(this.options.pattern, 'i');
       messagesToDelete = messagesToDelete.filter(msg => regex.test(msg.content));

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -31,7 +31,7 @@ class UndiscordCore {
     includePinned: null, // Delete messages that are pinned
     pattern: null, // Only delete messages that match the regex (insensitive)
     searchDelay: null, // Delay each time we fetch for more messages
-    includeApplications: null,
+    includeApplications: null, //Include application/bot messages
     deleteDelay: null, // Delay between each delete operation
     maxAttempt: 2, // Attempts to delete a single message if it fails
     askForConfirmation: true,
@@ -314,9 +314,12 @@ class UndiscordCore {
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
     
     // if the user provided an author.Id and doesn't wish to include applications, skip all messages that aren't created by the author.Id.
-    // fixes issues with bots & applications hanging the deletion.
-    if (!this.options.includeApplications) {
-        if (this.options.authorId) messagesToDelete = messagesToDelete.filter(msg => msg.author.id === this.options.authorId);
+    // fixes issues with bots & applications hanging the deletion
+    if (this.options.includeApplications == false) {
+      log.verb("IncludeApplications filter is false. Skipping bots and applications...")
+    }
+    if (this.options.includeApplications == false) {
+      messagesToDelete = messagesToDelete.filter(msg => !msg.author.bot);
     }
      // custom filter of messages
     try {

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -259,7 +259,7 @@ async function startAction() {
   const hasFile = $('input#hasFile').checked;
   const includePinned = $('input#includePinned').checked;
   const pattern = $('input#pattern').value;
-  const includeApplications = $('input#includeApplications').value;
+  const includeApplications = $('input#includeApplications').checked;
   // message interval
   const minId = $('input#minId').value.trim();
   const maxId = $('input#maxId').value.trim();
@@ -292,6 +292,7 @@ async function startAction() {
     content,
     hasLink,
     hasFile,
+    includeApplications,
     includeNsfw,
     includePinned,
     pattern,

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -259,6 +259,7 @@ async function startAction() {
   const hasFile = $('input#hasFile').checked;
   const includePinned = $('input#includePinned').checked;
   const pattern = $('input#pattern').value;
+  const includeApplications = $('input#includeApplications').value;
   // message interval
   const minId = $('input#minId').value.trim();
   const maxId = $('input#maxId').value.trim();
@@ -268,7 +269,7 @@ async function startAction() {
   //advanced
   const searchDelay = parseInt($('input#searchDelay').value.trim());
   const deleteDelay = parseInt($('input#deleteDelay').value.trim());
- 
+   
   // token
   const authToken = $('input#token').value.trim() || fillToken();
   if (!authToken) return; // get token already logs an error.


### PR DESCRIPTION
Fixes #476, #535 and #487. Undiscord attempts to delete application/bot messages initialized by the user, but receives a 403 error and hangs.

## Features

#### Provides a UI option under the filter category
![imssage](https://github.com/victornpb/undiscord/assets/154926234/f252d0db-7487-4bab-a248-b2e8ecaed7e5)

#### Provides a console log that bot messages will be skipped
![asdasdasdasdasdasd](https://github.com/victornpb/undiscord/assets/154926234/49ddaabc-0b76-4ed6-8705-6ba92ea12524)

#### Works on an elegantly simple filter.
~line 318 of undiscord-core.js
```js
if (this.options.IncludeApplications == false) {
    messagesToDelete = messagesToDelete.filter(msg => !msg.author.bot)
}
```
