### PR TITLE
Add filter for exclusing messages with files / attachments

### DIFF
--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -101,6 +101,9 @@
                         <label><input id="hasFile" type="checkbox">has: file</label>
                     </div>
                     <div class="sectionDescription">
+                        <label><input id="hasNoFile" type="checkbox">does not have: file</label>
+                    </div>
+                    <div class="sectionDescription">
                         <label><input id="includePinned" type="checkbox">Include pinned</label>
                     </div>
                 </fieldset>

--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -27,6 +27,7 @@ class UndiscordCore {
     content: null, // Filter messages that contains this text content
     hasLink: null, // Filter messages that contains link
     hasFile: null, // Filter messages that contains file
+    hasNoFile: null, // Filter messages that contains no file (opposite of hasFile)
     includeNsfw: null, // Search in NSFW channels
     includePinned: null, // Delete messages that are pinned
     pattern: null, // Only delete messages that match the regex (insensitive)
@@ -124,6 +125,7 @@ class UndiscordCore {
       `maxId = "${redact(this.options.maxId)}"`,
       `hasLink = ${!!this.options.hasLink}`,
       `hasFile = ${!!this.options.hasFile}`,
+      `hasNoFile = ${!!this.options.hasNoFile}`,
     );
 
     if (this.onStart) this.onStart(this.state, this.stats);
@@ -311,6 +313,12 @@ class UndiscordCore {
     let messagesToDelete = discoveredMessages;
     messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
+
+    // if the user picked hasNoFile, we need to filter out messages with attachments
+		// this has to be done after the search because the search API doesn't have a filter for this
+		if (this.options.hasNoFile) {
+			messagesToDelete = messagesToDelete.filter(msg => !msg.attachments.length);
+		}
 
     // custom filter of messages
     try {

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -141,10 +141,10 @@ function initUI() {
   $('button#getToken').onclick = () => $('input#token').value = fillToken();
   $('input#hasFile').onclick = function() {
     validateHasFileFilter(this);
-  }
+  };
   $('input#hasNoFile').onclick = function() {
     validateHasFileFilter(this);
-  }
+  };
 
   // sync delays
   $('input#searchDelay').onchange = (e) => {

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -89,6 +89,15 @@ function initUI() {
     }
   }
 
+  function validateHasFileFilter(clickedElement) {
+    const hasFile = $('input#hasFile');
+    const hasNoFile = $('input#hasNoFile');
+    if (hasFile.checked && hasNoFile.checked) {
+      clickedElement.checked = false;
+      alert('You cannot have both "Has File" and "Has No File" checked at the same time. Please uncheck one of them.');
+    }
+  }
+
   // cached elements
   ui.logArea = $('#logArea');
   ui.autoScroll = $('#autoScroll');
@@ -130,6 +139,12 @@ function initUI() {
     toggleWindow();
   };
   $('button#getToken').onclick = () => $('input#token').value = fillToken();
+  $('input#hasFile').onclick = function() {
+    validateHasFileFilter(this);
+  }
+  $('input#hasNoFile').onclick = function() {
+    validateHasFileFilter(this);
+  }
 
   // sync delays
   $('input#searchDelay').onchange = (e) => {
@@ -257,6 +272,7 @@ async function startAction() {
   const content = $('input#search').value.trim();
   const hasLink = $('input#hasLink').checked;
   const hasFile = $('input#hasFile').checked;
+  const hasNoFile = $('input#hasNoFile').checked;
   const includePinned = $('input#includePinned').checked;
   const pattern = $('input#pattern').value;
   // message interval
@@ -291,6 +307,7 @@ async function startAction() {
     content,
     hasLink,
     hasFile,
+    hasNoFile,
     includeNsfw,
     includePinned,
     pattern,


### PR DESCRIPTION
I had a use case where I wanted to EXCLUDE any messages with files/attachments from being deleted. The discord search API does not support this, so I added functionality by filtering out the messages locally.

I've also added validation to ensure that the user doesn't check both hasFile and hasNoFile, as that would just result in nothing happening

I've manually tested this to ensure that the new filter option works as intended, and the pre-existing ones still work as well.

Updated UI:
<img width="248" alt="image" src="https://github.com/user-attachments/assets/bf2f3584-a20a-415f-967e-7d1bf24b9edc">
Filter validation:
<img width="466" alt="image" src="https://github.com/user-attachments/assets/a0094a91-cdda-47a4-ace0-f6efde875272">
