### PR TITLE
Fixed query selector: Making Undiscord work again

### DIFF
--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -62,7 +62,7 @@ function initUI() {
   ui.undiscordBtn = createElm(buttonHtml);
   ui.undiscordBtn.onclick = toggleWindow;
   function mountBtn() {
-    const toolbar = document.querySelector('#app-mount [class^=toolbar]');
+    const toolbar = document.querySelector('#app-mount [class^=trailing]');
     if (toolbar) toolbar.appendChild(ui.undiscordBtn);
   }
   mountBtn();


### PR DESCRIPTION
Discord's recent UI update broke the `[class^=toolbar]` selector used to mount the delete button.
Updated it to `[class^=trailing]`, fixing the issue and restoring functionality.