### PR TITLE
Undiscord v5.2.4 with fixes. UPDATE: Goodbye. I should have switched to Discrub ages ago. It is available on the Google Web Store, has a 4.5 rating with over 220 reviews, and is being actively maintained.

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -570,6 +570,8 @@
 	      this.calcEtr();
 	      log.verb(`Estimated time remaining: ${msToHMS(this.stats.etr)}`);
 
+	      const messagesRemaining = this.state.grandTotal - this.state.offset;
+
 	      // if there are messages to delete, delete them
 	      if (this.state._messagesToDelete.length > 0) {
 
@@ -588,6 +590,9 @@
 	        log.verb('There\'s nothing we can delete on this page, checking next page...');
 	        log.verb(`Skipped ${this.state._skippedMessages.length} out of ${this.state._seachResponse.messages.length} in this page.`, `(Offset was ${oldOffset}, ajusted to ${this.state.offset})`);
 	      }
+	      else if (this.state.delCount < messagesRemaining) {
+	        log.verb('There\'s messages remaining, checking next page...');
+	      }		      
 	      else {
 	        log.verb('Ended because API returned an empty page.');
 	        log.verb('[End state]', this.state);

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -43,7 +43,7 @@
 #undiscord .input-wrapper { display: flex; align-items: center; font-size: 16px; box-sizing: border-box; width: 100%; border-radius: 3px; color: var(--text-default); background-color: var(--input-background); border: none; transition: border-color 0.2s ease-in-out 0s; }
 #undiscord input[type="text"],
 #undiscord input[type="search"],
-#undiscord input[type="password"],
+#undiscord input[type="text"],
 #undiscord input[type="datetime-local"],
 #undiscord input[type="number"],
 #undiscord input[type="range"] { background-color: var(--input-background); border: 1px solid var(--input-border); border-radius: 8px; box-sizing: border-box; color: var(--text-default); font-size: 16px; height: 44px; padding: 12px 10px; transition: border-color .2s ease-in-out; width: 100%; }
@@ -356,7 +356,7 @@
                     </legend>
                     <div class="multiInput">
                         <div class="input-wrapper">
-                            <input class="input" id="token" type="password" autocomplete="dont" priv>
+                            <input class="input" id="token" type="text" priv>
                         </div>
                         <button id="getToken">fill</button>
                     </div>

--- a/src/ui/main.css
+++ b/src/ui/main.css
@@ -28,10 +28,10 @@
 
 /**** Undiscord Interface ****/
 #undiscord {
-    position: fixed;
+    position: right;
     z-index: 100;
     top: 58px;
-    right: 10px;
+    right: 44px;
     display: flex;
     flex-direction: column;
     width: 800px;


### PR DESCRIPTION
For over a year, Undiscord was unusable because of 401 errors. This error was caused because Undiscord was auto filling the authentication token text box with the user's Discord password. This is alarming. Our Discord password should not be auto inserted anywhere without our permission. And the 401 error prevents us from using Undiscord. The fix is extremely simple. Just replace the word "password" with the word "text". Now there is no 401 error, the user will be able to use Undiscord, and they will feel safer knowing that their Discord password isn't being auto inserted anywhere.

Another thing is that Undiscord will not be visible if the user makes their browser a certain size. What happens is the Undiscord window will be mostly off screen. Only the left edge of the Undiscord window will be visible, if even that. The fix is extremely simple. Just change position: fixed to position: right. Now, no matter how small the browser is made, the Undiscord window will be visible under the Undiscord trash icon. I also changed right: 10px to right: 44px to better align stuff and make it aesthetically better.

Finally, some users reported that Undiscord would often stop working even though there are still messages left to delete. So someone proposed the following fix:
const messagesRemaining = this.state.grandTotal - this.state.offset;
I am going to assume it works, so I included it here. They also added a log.verb message to go along with it. Something like "There are messages remaining. Checking next page..."

I believe that these fixes are extremely simple and small but extremely important and necessary. These aforementioned bugs that have existed for over a year are very critical. It is very serious when people can't use Undiscord at all because they get a 401 eror. It is very serious when their Discord password is being inserted in Undiscord's authentication token box without their will. And it is very serious when someone makes their browser small and can't see the Undiscord window at all because it is positioned wrong and does not appear under the Undiscord trash icon. And if what that person said is true, it is very serious when Undiscord stops deleting messages for no reason even though it hasn't finished its job yet. All of these probably only take one line of text or a simple word replacement to fix. It isn't like the script is being completely re-written.

EDIT: I also want to add that I applied these fixes back in August 2024 and I have not had a single 401 error or any kind of error since then. But before I applied the fixes, Undiscord was completely unusable for me because of the 401 error. So in my case, and some other people's, these fixes are proven to work.