### PR TITLE
Added emptyPageRetries

### DIFF
--- a/src/ui/undiscord.html
+++ b/src/ui/undiscord.html
@@ -197,6 +197,14 @@
                         Use the help link for more information.
                     </div>
                 </fieldset>
+                <fieldset>
+                    <legend>
+                        Retries on API returned an empty page
+                    </legend>
+                    <div class="input-wrapper">
+                        <input id="emptyPageRetries" type="number" value="2" min="0" max="10">
+                    </div>
+                </fieldset>
                 <hr>
                 <fieldset>
                     <legend>

--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -140,6 +140,10 @@ function initUI() {
     const v = parseInt(e.target.value);
     if (v) undiscordCore.options.deleteDelay = v;
   };
+  $('input#emptyPageRetries').onchange = (e) => {
+    const v = parseInt(e.target.value);
+    if (v) undiscordCore.options.emptyPageRetries = v;
+  };
 
   $('input#searchDelay').addEventListener('input', (event) => {
     $('div#searchDelayValue').textContent = event.target.value + 'ms';
@@ -268,6 +272,7 @@ async function startAction() {
   //advanced
   const searchDelay = parseInt($('input#searchDelay').value.trim());
   const deleteDelay = parseInt($('input#deleteDelay').value.trim());
+  const emptyPageRetries = parseInt($('input#emptyPageRetries').value.trim());
  
   // token
   const authToken = $('input#token').value.trim() || fillToken();
@@ -296,6 +301,7 @@ async function startAction() {
     pattern,
     searchDelay,
     deleteDelay,
+    emptyPageRetries,
     // maxAttempt: 2,
   };
 


### PR DESCRIPTION
I added a setting in advanced options which allows you to specify how many times you'd like to retry deleting messages, after receiving the response from the API that "API returned an empty page". 

Thought I'd be a good idea after I kept receiving that API response, cancelling my deletion process when all it took is to press the 'start delete' button again. Now I don't have to continuously check if my deletion process was cancelled, and I can leave it be, knowing that it will automatically try again if I receive that message.