### PR TITLE
fix: `searchDelay` is `NaN` in ratelimit logic

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -260,7 +260,7 @@ class UndiscordCore {
     // not indexed yet
     if (resp.status === 202) {
       let w = (await resp.json()).retry_after * 1000;
-      w = w || this.stats.searchDelay; // Fix retry_after 0
+      w = w || this.options.searchDelay; // Fix retry_after 0
       this.stats.throttledCount++;
       this.stats.throttledTotalTime += w;
       log.warn(`This channel isn't indexed yet. Waiting ${w}ms for discord to index it...`);
@@ -272,12 +272,12 @@ class UndiscordCore {
       // searching messages too fast
       if (resp.status === 429) {
         let w = (await resp.json()).retry_after * 1000;
-        w = w || this.stats.searchDelay; // Fix retry_after 0
+        w = w || this.options.searchDelay; // Fix retry_after 0
 
         this.stats.throttledCount++;
         this.stats.throttledTotalTime += w;
-        this.stats.searchDelay += w; // increase delay
-        w = this.stats.searchDelay;
+        this.options.searchDelay += w; // increase delay
+        w = this.options.searchDelay;
         log.warn(`Being rate limited by the API for ${w}ms! Increasing search delay...`);
         this.printStats();
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);


### PR DESCRIPTION
`searchDelay` in the ratelimiting logic is being read from the `stats` object, as opposed to the `options` object. since this should be referencing `this.options.searchDelay`, we see `NaN` bugs when we reach this code:
<img width="744" height="148" alt="Screenshot 2025-11-06 at 4 38 30 PM" src="https://github.com/user-attachments/assets/77fb94cd-fa4d-4bc1-a6ae-7c97060cfcfd" />
this is a simple fix to update `this.stats.searchDelay`s to `this.options.searchDelay`

fixes #733 

---

note: my personal contributions to and usage of this project do not represent discord. opinions are my own