### PR TITLE
fix: no delay between batch jobs

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -32,6 +32,7 @@ class UndiscordCore {
     pattern: null, // Only delete messages that match the regex (insensitive)
     searchDelay: null, // Delay each time we fetch for more messages
     deleteDelay: null, // Delay between each delete operation
+    jobDelay: 30000, // Delay between each job during batches
     maxAttempt: 2, // Attempts to delete a single message if it fails
     askForConfirmation: true,
   };
@@ -86,6 +87,11 @@ class UndiscordCore {
 
     log.info(`Runnning batch with queue of ${queue.length} jobs`);
     for (let i = 0; i < queue.length; i++) {
+      if (i > 0) {
+        log.verb(`Waiting ${(this.options.jobDelay / 1000).toFixed(2)}s before next job...`);
+        await wait(this.options.jobDelay);
+      }
+
       const job = queue[i];
       log.info('Starting job...', `(${i + 1}/${queue.length})`);
 


### PR DESCRIPTION
when running batch jobs, the first api search for each job does not have any search delay. this is not a problem when running a single job, but when there are subsequent jobs, it will spam the api:

<img width="1172" height="1888" alt="image" src="https://github.com/user-attachments/assets/5890b56b-f8a0-4178-b75d-46154286b691" />

i believe this is a remnant of the code pre-batching, where such a delay is unneeded. i've added a simple check to apply a `jobDelay` before running if the current job is not the first one.

i'm not keen on making frontend changes so this option is currently backend only; i'd rather it be supported without UX to change it than to spam jobs >.<

---

note: my personal contributions to and usage of this project do not represent discord. opinions are my own