### PR TITLE
fix: missing permissions during search cancels entire batch job

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -284,8 +284,12 @@ class UndiscordCore {
 
         await wait(w * 2);
         return await this.search();
-      }
-      else {
+      } else if (resp.status === 403) {
+        // insufficient permissions -- guild is empty or specific channel isn't accessible
+        log.warn(`API responded with 403 - Insufficient Permissions when searching for messages:\n`, await resp.json());
+        this.state._seachResponse = {messages:[]};
+        return this.state._seachResponse;
+      } else {
         this.state.running = false;
         log.error(`Error searching messages, API responded with status ${resp.status}!\n`, await resp.json());
         throw resp;


### PR DESCRIPTION
in the case where a guild may have no visible channels, or if the provided list of channels has one where the user cannot access, a given batch job will fail ungracefully, causing all of the remaining queue to be discarded:
<img width="546" height="175" alt="Screenshot 2025-11-07 at 4 42 36 PM" src="https://github.com/user-attachments/assets/5e6f0556-b03b-4c4b-a064-5b8f5d21bb6c" />
<img width="3446" height="2090" alt="image" src="https://github.com/user-attachments/assets/be4c303e-ce22-4b0a-924f-8fb223765b45" />

i think a more elegant solution here is to return an empty search response, log a warning, and proceed as if the api returned no results (which defaults to exiting, or going to the next job if it is a batch)

### testing

this works locally for me to skip jobs with guilds or channels that have insufficient read permissions c:

---

note: my personal contributions to and usage of this project do not represent discord. opinions are my own