### PR TITLE
feat: delete polls & fix: undeletable bot cmd responses

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -309,7 +309,8 @@ class UndiscordCore {
 
     // we can only delete some types of messages, system messages are not deletable.
     let messagesToDelete = discoveredMessages;
-    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || (msg.type >= 6 && msg.type <= 21));
+    // type 46 = polls (self-deletable)
+    messagesToDelete = messagesToDelete.filter(msg => msg.type === 0 || msg.type === 46 || (msg.type >= 6 && msg.type <= 19));
     messagesToDelete = messagesToDelete.filter(msg => msg.pinned ? this.options.includePinned : true);
 
     // custom filter of messages


### PR DESCRIPTION
message type 46 are polls, which are self-deletable c: 
<img width="1084" height="767" alt="Screenshot 2025-11-13 at 11 28 44 AM" src="https://github.com/user-attachments/assets/63f1af96-5220-4bf2-9c06-d329b8e916d0" />

message type 20 are bot command responses, which are unfortunately not deletable without `Delete Messages` permissions (but will still show up in the search endpoint):
<img width="724" height="694" alt="Screenshot 2025-11-13 at 11 26 20 AM" src="https://github.com/user-attachments/assets/f676c89d-f768-40e4-80f1-8716286dce00" />

these changes have been tested and function as expected ^^

fixes #487 

---

note: my personal contributions to and usage of this project do not represent discord. opinions are my own