### PR TITLE
fix: insufficient perms retry-looping indefinitely

### DIFF
--- a/src/undiscord-core.js
+++ b/src/undiscord-core.js
@@ -396,6 +396,11 @@ class UndiscordCore {
         log.verb(`Cooling down for ${w * 2}ms before retrying...`);
         await wait(w * 2);
         return 'RETRY';
+      } else if (resp.status === 403) {
+        log.warn('Insufficient permissions to delete message. Skipping...');
+        this.state.offset++;
+        this.state.failCount++;
+        return 'FAIL_SKIP';
       } else {
         const body = await resp.text();
 


### PR DESCRIPTION
when trying to delete a message with insufficient permissions, the code will not adjust the offset and thus will continually re-grab the message and retry deleting it.

this change simply adjusts the offset upon 403 Insufficient Permissions responses

fixes #637 

---

note: my personal contributions to and usage of this project do not represent discord. opinions are my own