### PR TITLE
discord roll back this class

### DIFF
--- a/src/undiscord-ui.js
+++ b/src/undiscord-ui.js
@@ -62,7 +62,7 @@ function initUI() {
   ui.undiscordBtn = createElm(buttonHtml);
   ui.undiscordBtn.onclick = toggleWindow;
   function mountBtn() {
-    const toolbar = document.querySelector('#app-mount [class*="-toolbar"]');
+    const toolbar = document.querySelector('#app-mount [class^="toolbar"]');
     if (toolbar) toolbar.appendChild(ui.undiscordBtn);
   }
   mountBtn();


### PR DESCRIPTION
discord roll back this class

You can roll back 

`- const toolbar = document.querySelector('#app-mount [class*="-toolbar"]');`
`+ const toolbar = document.querySelector('#app-mount [class^="toolbar"]');` (This PR)

or scope by parent for compatibly with new and old ui with minimal side effects :

`+const toolbar = document.querySelector('#app-mount [class*="upperContainer"] > [class*="toolbar"]');`
or just the two option 
`+const toolbar = document.querySelector('#app-mount [class*="-toolbar"], #app-mount [class^="toolbar_"]');`

edit  : my commit **i erase the last \n** of file i can re-open PR  if you want